### PR TITLE
Add Peek- and PokeNode functions to MapBlk

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -11,3 +11,9 @@ func (mb *MapBlk) PeekNode(i int) mt.Node {
 		Param2: mb.Param2[i],
 	}
 }
+
+func (mb *MapBlk) PokeNode(i int, node mt.Node) {
+	mb.Param0[i] = node.Param0
+	mb.Param1[i] = node.Param1
+	mb.Param2[i] = node.Param2
+}

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,13 @@
+package mtmap
+
+import (
+	"github.com/anon55555/mt"
+)
+
+func (mb MapBlk) PickNode(i int) mt.Node {
+	return mt.Node{
+		Param0: mb.Param0[i],
+		Param1: mb.Param1[i],
+		Param2: mb.Param2[i],
+	}
+}

--- a/tools.go
+++ b/tools.go
@@ -4,7 +4,7 @@ import (
 	"github.com/anon55555/mt"
 )
 
-func (mb MapBlk) PickNode(i int) mt.Node {
+func (mb *MapBlk) PeekNode(i int) mt.Node {
 	return mt.Node{
 		Param0: mb.Param0[i],
 		Param1: mb.Param1[i],


### PR DESCRIPTION
PeekNode and PokeNode change signle nodes in MapBlks

```golang
func (mb *MapBlk) PeekNode(i int) mt.Node {
	return mt.Node{
		Param0: mb.Param0[i],
		Param1: mb.Param1[i],
		Param2: mb.Param2[i],
	}
}

func (mb *MapBlk) PokeNode(i int, node mt.Node) {
	mb.Param0[i] = node.Param0
	mb.Param1[i] = node.Param1
	mb.Param2[i] = node.Param2
}
```

Naming inspired by commodore-basic (https://en.wikipedia.org/wiki/Commodore_BASIC)

Where peek returns the value of a address and poke changes it
